### PR TITLE
feat: add optional Icon field to Goal model and implement tests

### DIFF
--- a/CommBank-Server/CommBank.csproj
+++ b/CommBank-Server/CommBank.csproj
@@ -1,35 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>CommBank_Server</RootNamespace>
     <AssemblyName>CommBank-Server</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="Newtonsoft.Json" />
-    <None Remove="BCrypt.Net-Next" />
-    <None Remove="Microsoft.Extensions.DependencyInjection" />
-    <None Remove="MongoDB.Driver" />
-    <None Remove="Services\" />
-    <None Remove="Models\" />
-    <None Remove="Properties\" />
-    <None Remove="Data\" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Services\" />
-    <Folder Include="Models\" />
-    <Folder Include="Properties\" />
-    <Folder Include="Data\" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/CommBank-Server/Models/Goal.cs
+++ b/CommBank-Server/Models/Goal.cs
@@ -1,4 +1,4 @@
-﻿using MongoDB.Bson;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace CommBank.Models;
@@ -27,4 +27,5 @@ public class Goal
 
     [BsonRepresentation(BsonType.ObjectId)]
     public string? UserId { get; set; }
+    public string? Icon { get; set; }
 }

--- a/CommBank-Server/Program.cs
+++ b/CommBank-Server/Program.cs
@@ -1,4 +1,4 @@
-﻿using CommBank.Models;
+using CommBank.Models;
 using CommBank.Services;
 using MongoDB.Driver;
 
@@ -12,7 +12,7 @@ builder.Services.AddSwaggerGen();
 builder.Configuration.SetBasePath(Directory.GetCurrentDirectory()).AddJsonFile("Secrets.json");
 
 var mongoClient = new MongoClient(builder.Configuration.GetConnectionString("CommBank"));
-var mongoDatabase = mongoClient.GetDatabase("CommBank");
+var mongoDatabase = mongoClient.GetDatabase("CommBankDb");
 
 IAccountsService accountsService = new AccountsService(mongoDatabase);
 IAuthService authService = new AuthService(mongoDatabase);

--- a/CommBank-Server/appsettings.json
+++ b/CommBank-Server/appsettings.json
@@ -1,10 +1,14 @@
-﻿{
+{
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "CommBankDatabaseSettings": {
+    "ConnectionString": "mongodb+srv://johnkasonga0572:CommBank2026@commbankcluster.5m6wolc.mongodb.net/?appName=CommBankCluster",
+    "DatabaseName": "CommBankDb",
+    "GoalsCollectionName": "Goals"
+  }
 }
-

--- a/CommBank.Tests/CommBank.Tests.csproj
+++ b/CommBank.Tests/CommBank.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/CommBank.Tests/GoalControllerTests.cs
+++ b/CommBank.Tests/GoalControllerTests.cs
@@ -3,18 +3,14 @@ using CommBank.Services;
 using CommBank.Models;
 using CommBank.Tests.Fake;
 using Microsoft.AspNetCore.Mvc;
-
 namespace CommBank.Tests;
-
 public class GoalControllerTests
 {
     private readonly FakeCollections collections;
-
     public GoalControllerTests()
     {
         collections = new();
     }
-
     [Fact]
     public async void GetAll()
     {
@@ -24,12 +20,10 @@ public class GoalControllerTests
         IGoalsService goalsService = new FakeGoalsService(goals, goals[0]);
         IUsersService usersService = new FakeUsersService(users, users[0]);
         GoalController controller = new(goalsService, usersService);
-
         // Act
         var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
         controller.ControllerContext.HttpContext = httpContext;
         var result = await controller.Get();
-
         // Assert
         var index = 0;
         foreach (Goal goal in result)
@@ -40,7 +34,6 @@ public class GoalControllerTests
             index++;
         }
     }
-
     [Fact]
     public async void Get()
     {
@@ -50,25 +43,37 @@ public class GoalControllerTests
         IGoalsService goalsService = new FakeGoalsService(goals, goals[0]);
         IUsersService usersService = new FakeUsersService(users, users[0]);
         GoalController controller = new(goalsService, usersService);
-
         // Act
         var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
         controller.ControllerContext.HttpContext = httpContext;
         var result = await controller.Get(goals[0].Id!);
-
         // Assert
         Assert.IsAssignableFrom<Goal>(result.Value);
         Assert.Equal(goals[0], result.Value);
         Assert.NotEqual(goals[1], result.Value);
     }
-
     [Fact]
     public async void GetForUser()
     {
         // Arrange
-        
+        var goals = collections.GetGoals();
+        var users = collections.GetUsers();
+        IGoalsService goalsService = new FakeGoalsService(goals, goals[0]);
+        IUsersService usersService = new FakeUsersService(users, users[0]);
+        GoalController controller = new(goalsService, usersService);
         // Act
-        
+        var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+        controller.ControllerContext.HttpContext = httpContext;
+        var result = await controller.GetForUser(users[0].Id!);
         // Assert
+        Assert.NotNull(result);
+        var index = 0;
+        foreach (Goal goal in result!)
+        {
+            Assert.IsAssignableFrom<Goal>(goal);
+            Assert.Equal(goals[index].Id, goal.Id);
+            Assert.Equal(goals[index].Name, goal.Name);
+            index++;
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds icon support to the Goal model and covers the GetGoalsForUser route with unit tests.

## Changes
- Added optional `Icon` field (string?) to the Goal model in Goal.cs
- Updated appsettings.json and Program.cs to connect to MongoDB Atlas
- Updated CommBank.csproj to target net9.0
- Implemented GetForUser unit test in GoalControllerTests.cs
- Updated CommBank.Tests.csproj to target net9.0

## Testing
- All 11 unit tests pass (dotnet test)
- API tested with Postman - GET /api/goal returns goals with icon field