### PR TITLE
feat: Add icon field and unit tests to Goal API

### DIFF
--- a/CommBank-Server/Models/Goal.cs
+++ b/CommBank-Server/Models/Goal.cs
@@ -27,4 +27,6 @@ public class Goal
 
     [BsonRepresentation(BsonType.ObjectId)]
     public string? UserId { get; set; }
+
+    public string? Icon { get; set; } 
 }

--- a/CommBank-Server/Program.cs
+++ b/CommBank-Server/Program.cs
@@ -9,9 +9,9 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Configuration.SetBasePath(Directory.GetCurrentDirectory()).AddJsonFile("Secrets.json");
+// builder.Configuration.SetBasePath(Directory.GetCurrentDirectory()).AddJsonFile("Secrets.json");
 
-var mongoClient = new MongoClient(builder.Configuration.GetConnectionString("CommBank"));
+var mongoClient = new MongoClient(builder.Configuration.GetConnectionString("MongoDb"));
 var mongoDatabase = mongoClient.GetDatabase("CommBank");
 
 IAccountsService accountsService = new AccountsService(mongoDatabase);

--- a/CommBank-Server/Services/GoalService.cs
+++ b/CommBank-Server/Services/GoalService.cs
@@ -9,7 +9,7 @@ public class GoalsService : IGoalsService
 
     public GoalsService(IMongoDatabase mongoDatabase)
     {
-        _goalsCollection = mongoDatabase.GetCollection<Goal>("Goals");
+        _goalsCollection = mongoDatabase.GetCollection<Goal>("goals");
     }
 
     public async Task<List<Goal>> GetAsync() =>

--- a/CommBank-Server/appsettings.json
+++ b/CommBank-Server/appsettings.json
@@ -5,6 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "MongoDb": "mongodb+srv://abdulkhan20041_db_user:XKstw18nNawvXBUO@cluster0.8r5eqlm.mongodb.net/commbank"
+  }
 }
-

--- a/CommBank.Tests/CommBank.Tests.csproj
+++ b/CommBank.Tests/CommBank.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CommBank.Tests/GoalsControllerTests.cs
+++ b/CommBank.Tests/GoalsControllerTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+using Moq;
+using CommBank.Controllers;
+using CommBank.Models;
+using CommBank.Services;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CommBank.Tests
+{
+    public class GoalsControllerTests
+    {
+        [Fact]
+        public async Task GetGoalsForUser_ReturnsGoals_ForValidUser()
+        {
+            // ARRANGE
+            var userId = "user123";
+
+            var fakeGoals = new List<Goal>
+{
+    new Goal { Id = "1", Name = "Save for car", Icon = "🚗", UserId = userId },
+    new Goal { Id = "2", Name = "Holiday fund", Icon = "✈️", UserId = userId }
+};
+
+            var mockService = new Mock<IGoalsService>();
+            mockService
+                .Setup(s => s.GetForUserAsync(userId))
+                .ReturnsAsync(fakeGoals);
+
+            var mockUserService = new Mock<IUsersService>();
+
+var controller = new GoalController(
+    mockService.Object,
+    mockUserService.Object
+);
+
+            
+
+            // ⚠️ IMPORTANT: handle ActionResult
+            var result = await controller.GetForUser(userId);
+
+            // ASSERT
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal("🚗", result[0].Icon);
+        }
+    }
+}


### PR DESCRIPTION
## What I changed

- Added optional `Icon` field to Goal model
- Updated GoalController to support icon in GET and PUT
- Ensured icon persists in database
- Added unit tests for GetForUser method using xUnit and Moq

## How to test
1. Run backend: dotnet run
2. Use Postman:
   GET /api/Goal/User/{userId}
   → should include icon field

3. Update goal:
   PUT /api/Goal/{id}
   {
     "name": "Save Money",
     "icon": "💰"
   }

4. Run tests:
   dotnet test