### PR TITLE
Icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ autom4te.cache/
 tarballs/
 test-results/
 
+# Local secrets - never commit
+Secrets.json
+
 # Mac bundle stuff
 *.dmg
 *.app

--- a/CommBank-Server/CommBank.csproj
+++ b/CommBank-Server/CommBank.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net80</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>CommBank_Server</RootNamespace>
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommBank-Server/CommBank.csproj
+++ b/CommBank-Server/CommBank.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>CommBank_Server</RootNamespace>
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommBank-Server/Models/Goal.cs
+++ b/CommBank-Server/Models/Goal.cs
@@ -27,4 +27,6 @@ public class Goal
 
     [BsonRepresentation(BsonType.ObjectId)]
     public string? UserId { get; set; }
+
+    public string? Icon { get; set; }
 }

--- a/CommBank-Server/Secrets.json
+++ b/CommBank-Server/Secrets.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "CommBank": "{CONNECTION_STRING}"
+    "CommBank": "mongodb+srv://oragvelidzeniko2024_db_user:JnsIuSd8smh7Sbxu@cluster0.4uny9uv.mongodb.net/?appName=Cluster0"
   }
 }

--- a/CommBank-Server/Secrets.json
+++ b/CommBank-Server/Secrets.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "CommBank": "mongodb+srv://oragvelidzeniko2024_db_user:JnsIuSd8smh7Sbxu@cluster0.4uny9uv.mongodb.net/?appName=Cluster0"
+    "CommBank": "{CONNECTION_STRING}"
   }
 }

--- a/CommBank.Tests/GoalControllerTests.cs
+++ b/CommBank.Tests/GoalControllerTests.cs
@@ -66,9 +66,26 @@ public class GoalControllerTests
     public async void GetForUser()
     {
         // Arrange
-        
-        // Act
-        
-        // Assert
+       var goals = collections.GetGoals();
+       var users = collections.GetUsers();
+       IGoalsService goalsService = new FakeGoalsService(goals, goals[0]);
+       IUsersService usersService = new FakeUsersService(users, users[0]);
+       GoalController controller = new(goalsService, usersService);
+
+       // Act
+       var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+       controller.ControllerContext.HttpContext = httpContext;
+       var result = await controller.GetForUser(goals[0].UserId!);
+
+       // Assert
+       Assert.NotNull(result);
+
+       var index = 0;
+       foreach (Goal goal in result!)
+       {
+           Assert.IsAssignableFrom<Goal>(goal);
+           Assert.Equal(goals[0].UserId, goal.UserId);
+           index++;
+        }
     }
 }


### PR DESCRIPTION
## Summary
Wires up icon persistence end-to-end and adds backend test coverage.

- Added `updateGoal` PUT request in `lib.ts` to persist goal updates (including `icon`) to `/api/Goal/{goalId}`.
- Finished `pickEmojiOnClick` in `GoalManager.tsx`: builds the updated `Goal` from `props.goal`, merging in pending local `name`/`targetDate`/`targetAmount` state, then dispatches to Redux and calls `updateGoal` so the icon change persists across a client refresh.
- Added a `GetForUser` test in `GoalControllerTests.cs` covering the `GetGoalsForUser` route — asserts the result isn't null and each returned `Goal` is correctly typed with the expected `UserId`.

## Testing
- Verified via Postman: `PUT /api/Goal/{id}` returns `204`, and a follow-up `GET` confirms the icon change persisted server-side.
- Manually verified in the app: picking an emoji updates immediately and survives a hard refresh.
- `dotnet test` passes for the full suite, including the new `GetForUser` test.