### PR TITLE
Add tests for GetGoalsForUser

### DIFF
--- a/CommBank-Server/Models/Goal.cs
+++ b/CommBank-Server/Models/Goal.cs
@@ -11,6 +11,8 @@ public class Goal
 
     public string? Name { get; set; }
 
+    public string? Icon { get; set; }
+
     public UInt64 TargetAmount { get; set; } = 0;
 
     public DateTime TargetDate { get; set; }

--- a/CommBank.Tests/GoalControllerTests.cs
+++ b/CommBank.Tests/GoalControllerTests.cs
@@ -62,13 +62,34 @@ public class GoalControllerTests
         Assert.NotEqual(goals[1], result.Value);
     }
 
-    [Fact]
-    public async void GetForUser()
+[Fact]
+public async void GetForUser()
+{
+    // Arrange
+    var goals = collections.GetGoals();
+    var users = collections.GetUsers();
+
+    IGoalsService goalsService = new FakeGoalsService(goals, goals[0]);
+    IUsersService usersService = new FakeUsersService(users, users[0]);
+
+    GoalController controller = new(goalsService, usersService);
+
+    // Act
+    var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+    controller.ControllerContext.HttpContext = httpContext;
+
+    var result = await controller.GetForUser(users[0].Id!);
+
+    // Assert
+    Assert.NotNull(result);
+    Assert.IsAssignableFrom<List<Goal>>(result);
+
+    var index = 0;
+    foreach (Goal goal in result)
     {
-        // Arrange
-        
-        // Act
-        
-        // Assert
+        Assert.IsAssignableFrom<Goal>(goal);
+        Assert.Equal(goals[index].Id, goal.Id);
+        Assert.Equal(goals[index].Name, goal.Name);
+        index++;
     }
-}
+}}


### PR DESCRIPTION
Added unit tests for the GetGoalsForUser route in GoalController.

The tests verify that the route returns Goal objects correctly for a user.
All existing tests pass successfully.